### PR TITLE
GitHubCI: add build/pack/push steps for Xamarin.Forms.nuspec

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,36 +8,60 @@ jobs:
         # NOTE!!: sync with version number in Xamarin.Forms.Platform.GTK.csproj
         BASE_VERSION: 5.0.0.2515
         DEFAULT_REF_TO_NUGET_PUSH: refs/heads/5.0.0
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
     - uses: actions/checkout@v1
     - name: Download Nuget.exe
       uses: NuGet/setup-nuget@v1.0.5
       with:
         nuget-version: 5.4.0
+        
     - name: setup-msbuild
       uses: microsoft/setup-msbuild@v1
-    - name: Restore & Build
+
+    - name: Restore
+      run: msbuild /restore Xamarin.Forms.sln
+    
+    - name: Build
+      run: msbuild .\Xamarin.Forms.sln -p:Configuration=Release
+
+    - name: Package and Upload
+      run: |
+        git clone https://github.com/nblockchain/fsx
+        $env:DOTNETFORMS_VERSION = `.\fsx\Tools\fsi.bat fsx\Tools\nugetPush.fsx --output-version $env:BASE_VERSION`
+
+        echo ("DOTNETFORMS_VERSION=$env:DOTNETFORMS_VERSION") >> $env:GITHUB_ENV
+
+        nuget pack .nuspec/Xamarin.Forms.nuspec -p "version=$env:DOTNETFORMS_VERSION;Configuration=Release"
+
+        If ($Env:GITHUB_REF -eq $Env:DEFAULT_REF_TO_NUGET_PUSH) {
+            If ('${{ secrets.NUGET_API_KEY }}' -ne '') {
+                nuget push **\DotNetForms*.nupkg -NoSymbols True -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}
+            }
+        }
+        
+    - name: GTK Restore & Build
       run: |
         nuget restore Xamarin.Forms.Platform.GTK\Xamarin.Forms.Platform.GTK.csproj
         msbuild Xamarin.Forms.Platform.GTK\Xamarin.Forms.Platform.GTK.csproj /property:Configuration=Release
-    - name: Package and upload
+
+    - name: GTK Package and upload
       run: |
         $buildConfiguration = "Release"
-        git clone https://github.com/nblockchain/fsx
-        $version = `.\fsx\Tools\fsi.bat fsx\Tools\nugetPush.fsx --output-version $env:BASE_VERSION`
-        
+
         # Replaces '$core_version$' and '$version$' in GTK nuspec file with XF.Core dependency version and version generated above for this commit
         # Powershell code copied from script https://github.com/xamarin/Xamarin.Forms/blob/5.0.0/build/steps/build-nuget.yml
         Get-ChildItem './.nuspec/*.GTK.nuspec' -Recurse | Foreach-Object {
              (Get-Content $_) | Foreach-Object  {
-                 $_ -replace '\$version\$', $version `
-                    -replace '\$core_version\$', $env:BASE_VERSION `
+                 $_ -replace '\$version\$', $env:DOTNETFORMS_VERSION `
+                    -replace '\$core_version\$', $env:DOTNETFORMS_VERSION `
                     -replace '\$Configuration\$', $buildConfiguration `
              } | Set-Content $_
         }
 
         nuget pack './.nuspec/Xamarin.Forms.Platform.GTK.nuspec'
+
+        $version = $env:DOTNETFORMS_VERSION
 
         If ($Env:GITHUB_REF -eq $Env:DEFAULT_REF_TO_NUGET_PUSH) {
             If ('${{ secrets.NUGET_API_KEY }}' -ne '') {

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ jobs:
         # NOTE!!: sync with version number in Xamarin.Forms.Platform.GTK.csproj
         BASE_VERSION: 5.0.0.2515
         DEFAULT_REF_TO_NUGET_PUSH: refs/heads/5.0.0
+        CONFIGURATION: Release
+
     runs-on: windows-2019
     steps:
     - uses: actions/checkout@v1
@@ -21,51 +23,20 @@ jobs:
 
     - name: Restore
       run: msbuild /restore Xamarin.Forms.sln
-    
+
     - name: Build
-      run: msbuild .\Xamarin.Forms.sln -p:Configuration=Release
+      run: msbuild .\Xamarin.Forms.sln -p:Configuration=${{env.CONFIGURATION}}
 
     - name: Package and Upload
       run: |
         git clone https://github.com/nblockchain/fsx
-        $env:DOTNETFORMS_VERSION = `.\fsx\Tools\fsi.bat fsx\Tools\nugetPush.fsx --output-version $env:BASE_VERSION`
+        $version = `.\fsx\Tools\fsi.bat fsx\Tools\nugetPush.fsx --output-version $env:BASE_VERSION`
 
-        echo ("DOTNETFORMS_VERSION=$env:DOTNETFORMS_VERSION") >> $env:GITHUB_ENV
-
-        nuget pack .nuspec/Xamarin.Forms.nuspec -p "version=$env:DOTNETFORMS_VERSION;Configuration=Release"
+        nuget pack .nuspec/Xamarin.Forms.nuspec -p "version=$version;Configuration=$env:CONFIGURATION"
+        nuget pack .nuspec/Xamarin.Forms.Platform.GTK.nuspec -p "version=$version;Configuration=$env:CONFIGURATION;core_version=$version"
 
         If ($Env:GITHUB_REF -eq $Env:DEFAULT_REF_TO_NUGET_PUSH) {
             If ('${{ secrets.NUGET_API_KEY }}' -ne '') {
                 nuget push **\DotNetForms*.nupkg -NoSymbols True -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}
-            }
-        }
-        
-    - name: GTK Restore & Build
-      run: |
-        nuget restore Xamarin.Forms.Platform.GTK\Xamarin.Forms.Platform.GTK.csproj
-        msbuild Xamarin.Forms.Platform.GTK\Xamarin.Forms.Platform.GTK.csproj /property:Configuration=Release
-
-    - name: GTK Package and upload
-      run: |
-        $buildConfiguration = "Release"
-
-        # Replaces '$core_version$' and '$version$' in GTK nuspec file with XF.Core dependency version and version generated above for this commit
-        # Powershell code copied from script https://github.com/xamarin/Xamarin.Forms/blob/5.0.0/build/steps/build-nuget.yml
-        Get-ChildItem './.nuspec/*.GTK.nuspec' -Recurse | Foreach-Object {
-             (Get-Content $_) | Foreach-Object  {
-                 $_ -replace '\$version\$', $env:DOTNETFORMS_VERSION `
-                    -replace '\$core_version\$', $env:DOTNETFORMS_VERSION `
-                    -replace '\$Configuration\$', $buildConfiguration `
-             } | Set-Content $_
-        }
-
-        nuget pack './.nuspec/Xamarin.Forms.Platform.GTK.nuspec'
-
-        $version = $env:DOTNETFORMS_VERSION
-
-        If ($Env:GITHUB_REF -eq $Env:DEFAULT_REF_TO_NUGET_PUSH) {
-            If ('${{ secrets.NUGET_API_KEY }}' -ne '') {
-                $fileName= "DotNetForms.Platform.GTK.$version.nupkg"
-                nuget push $fileName -ApiKey ${{secrets.NUGET_API_KEY}} -Source https://api.nuget.org/v3/index.json
             }
         }

--- a/.nuspec/Xamarin.Forms.Platform.GTK.nuspec
+++ b/.nuspec/Xamarin.Forms.Platform.GTK.nuspec
@@ -15,7 +15,7 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <group>
-        <dependency id="Xamarin.Forms" version="$core_version$" />
+        <dependency id="DotNetForms" version="$core_version$" />
         <dependency id="OpenTK" version="3.0.1" />
       </group>
     </dependencies>

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Xamarin.Forms</id>
+    <id>DotNetForms</id>
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>microsoft xamarin</owners>
     <tags>xamarin forms xamarinforms xamarin.forms</tags>
     <license type="expression">MIT</license>
     <icon>Assets\xamarin_128x128.png</icon>
-    <projectUrl>http://xamarin.com/forms</projectUrl>
-    <repository type="git" url="https://github.com/xamarin/xamarin.forms"/>
+    <projectUrl>https://github.com/nblockchain/DotNetForms</projectUrl>
+    <repository type="git" url="https://github.com/nblockchain/DotNetForms"/>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>Build native UIs for iOS, Android, UWP, macOS, Tizen and many more from a single, shared C# codebase</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -28,12 +28,6 @@
         <dependency id="Xamarin.AndroidX.RecyclerView" version="[1.2.1.1,1.3)" />
         <dependency id="Xamarin.AndroidX.Navigation.UI" version="[2.3.5.1,2.4)" />
       </group>
-      <group targetFramework="uap10.0.14393">
-        <dependency id="NETStandard.Library" version="2.0.1"/>
-        <dependency id="Win2D.uwp" version="1.20.0" />
-        <dependency id="Microsoft.UI.Xaml" version="2.1.190606001" />
-        <dependency id="System.ValueTuple" version="4.5.0" />
-      </group>
       <group targetFramework="uap10.0.16299">
         <dependency id="Win2D.uwp" version="1.20.0" />
         <dependency id="Microsoft.UI.Xaml" version="2.4.3" />
@@ -66,12 +60,6 @@
         <reference file="Xamarin.Forms.Xaml.dll" />
         <reference file="FormsViewGroup.dll" />
         <reference file="Xamarin.Forms.Platform.Android.dll" />
-      </group>
-      <group targetFramework="uap10.0.14393">
-        <reference file="Xamarin.Forms.Core.dll" />
-        <reference file="Xamarin.Forms.Platform.dll" />
-        <reference file="Xamarin.Forms.Xaml.dll" />
-        <reference file="Xamarin.Forms.Platform.UAP.dll" />
       </group>
       <group targetFramework="uap10.0.16299">
         <reference file="Xamarin.Forms.Core.dll" />
@@ -178,8 +166,6 @@
     <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\MonoAndroid10.0\Design" />
     <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\Xamarin.iOS10\Design" />
     <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\Xamarin.iOS10\Design" />
-    <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\uap10.0.14393\Design" />
-    <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\uap10.0.14393\Design" />
     <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\uap10.0.16299\Design" />
     <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\uap10.0.16299\Design" />
     <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\Xamarin.Mac\Design" />
@@ -223,20 +209,6 @@
     <file src="..\Stubs\Xamarin.Forms.Platform.iOS\bin\iPhone\$Configuration$\Xamarin.Forms.Platform.dll" target="lib\Xamarin.iOS10" />
 
     <!--UWP 14393-->
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP.dll" target="lib\uap10.0.14393" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP.*pdb" target="lib\uap10.0.14393" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\Xamarin.Forms.Platform.UAP.xr.xml" target="lib\uap10.0.14393\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Platform.dll" target="lib\uap10.0.14393" />
-    <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Platform.*pdb" target="lib\uap10.0.14393" />
-    <file src="..\Xamarin.Forms.Platform.UAP\Properties\Xamarin.Forms.Platform.UAP.rd.xml" target="lib\uap10.0.14393\Properties" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP.pri" target="lib\uap10.0.14393" />
-    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Core.dll" target="lib\uap10.0.14393" />
-    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Core.*pdb" target="lib\uap10.0.14393" />
-    <file src="..\build\docs\Xamarin.Forms.Core.xml" target="lib\uap10.0.14393" />
-    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Xaml.dll" target="lib\uap10.0.14393" />
-    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Xaml.*pdb" target="lib\uap10.0.14393" />
-    <file src="..\build\docs\Xamarin.Forms.Xaml.xml" target="lib\uap10.0.14393" />
-
     <!--UWP 16299-->
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.16299\Xamarin.Forms.Platform.UAP.dll" target="lib\uap10.0.16299" />
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.16299\Xamarin.Forms.Platform.UAP.*pdb" target="lib\uap10.0.16299" />
@@ -254,10 +226,8 @@
 
 
     <!-- VS 2017 needs these-->
-    <file src="..\Xamarin.Forms.Platform.UAP\obj\$Configuration$\uap10.0.14393\**\*.xaml" target="lib\uap10.0.14393\Xamarin.Forms.Platform.UAP" />
     <!-- VS 2017 needs these 16299-->
     <file src="..\Xamarin.Forms.Platform.UAP\obj\$Configuration$\uap10.0.16299\**\*.xaml" target="lib\uap10.0.16299\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\obj\$Configuration$\uap10.0.14393\Microsoft.UI.Xaml\**\*.xaml" target="lib\uap10.0.16299\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml" />
 
     <!--Mac-->
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.dll" target="lib\Xamarin.Mac" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <clear/>
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
-    <add key="nuget" value="../s/Nuget" />
   </packageSources>
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />

--- a/Xamarin.Forms.Platform.GTK/Xamarin.Forms.Platform.GTK.csproj
+++ b/Xamarin.Forms.Platform.GTK/Xamarin.Forms.Platform.GTK.csproj
@@ -96,9 +96,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="OpenTK" Version="3.0.1" />
-    <PackageReference Include="Xamarin.Forms">
-      <Version>5.0.0.2515</Version>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Xamarin.Forms.Core\Crc64.cs">
@@ -238,6 +235,12 @@
     <Compile Include="VisualElementRenderer.cs" />
     <Compile Include="VisualElementTracker.cs" />
     <Compile Include="GtkFormsContainer.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">
+      <Project>{57b8b73d-c3b5-4c42-869e-7b2f17d354ac}</Project>
+      <Name>Xamarin.Forms.Core</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />


### PR DESCRIPTION
- Update main.yml file to have build/pack/push steps for Xamarin.Forms.nuspec.
- Update Xamarin.Forms.Platform.GTK to depend on the newly built version of DotNetForms instead of Xamarin.Forms